### PR TITLE
Update To Match The Other Audio Banks

### DIFF
--- a/audio/engine_4.asm
+++ b/audio/engine_4.asm
@@ -3,7 +3,7 @@
 Audio4_PlaySound::
 	ld [wSoundID], a
 	ld a, [wSoundID]
-	cp $ff
+	cp SFX_STOP_ALL_MUSIC
 	jp z, .stopAllAudio
 	cp MAX_SFX_ID_4
 	jp z, .playSfx


### PR DESCRIPTION
All the other Audio engine banks have this as  SFX_STOP_ALL_MUSIC. However, Audio Engine 4 still has it as $ff.