### PR TITLE
Rename wd49b to wPikachuEmotionModifier

### DIFF
--- a/engine/events/pikachu_happiness.asm
+++ b/engine/events/pikachu_happiness.asm
@@ -73,7 +73,7 @@ ModifyPikachuHappiness::
 	jr c, .decreased
 	cp b
 	jr nc, .done
-	ld a, [wd49b]
+	ld a, [wPikachuEmotionModifier]
 	and a
 	jr nz, .done
 	jr .update_mood

--- a/engine/events/poison.asm
+++ b/engine/events/poison.asm
@@ -139,7 +139,7 @@ UpdatePikachuHappinessAndMood:
 	ld hl, wPikachuMood
 	ld a, [hl]
 	cp 128 ; central value
-	jr z, .update_wd49b ; mood == 128, don't modify it
+	jr z, .clearEmotionModifier ; mood == 128, don't modify it
 	jr c, .increaseMood ; mood < 128, must increase by 1
 	; mood > 128, must decrease by 1 (so decrease by 2 and then increase by 1)
 	dec a
@@ -147,10 +147,10 @@ UpdatePikachuHappinessAndMood:
 .increaseMood
 	inc a
 	ld [hl], a
-; if the mood has reached its "stable" central value, do not update wd49b
+; if the mood has reached its "stable" central value, do not update the emotion modifier
 	cp 128
 	ret nz
-.update_wd49b
+.clearEmotionModifier
 	xor a
-	ld [wd49b], a ; variable used in other mood-related functions, to keep track if the mood was "stable"
+	ld [wPikachuEmotionModifier], a ; variable used in other mood-related functions, to keep track if the mood was "stable"
 	ret

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -562,7 +562,7 @@ ItemUseBall:
 
 .skipShowingPokedexData
 	ld a, $1
-	ld [wd49b], a
+	ld [wPikachuEmotionModifier], a
 	ld a, $85
 	ld [wPikachuMood], a
 	ld a, [wPartyCount]
@@ -819,7 +819,7 @@ ItemUseEvoStone:
 	ld hl, RefusingText
 	call PrintText
 	ld a, $4
-	ld [wd49b], a
+	ld [wPikachuEmotionModifier], a
 	ld a, $82
 	ld [wPikachuMood], a
 	jr .canceledItemUse
@@ -2124,7 +2124,7 @@ FishingInit:
 	ld a, SFX_HEAL_AILMENT
 	call PlaySound
 	ld a, $2
-	ld [wd49b], a
+	ld [wPikachuEmotionModifier], a
 	ld a, $81
 	ld [wPikachuMood], a
 	ld c, 80
@@ -2507,7 +2507,7 @@ ItemUseTMHM:
 	jr nz, .notTeachingThunderboltOrThunderToPikachu
 .teachingThunderboltOrThunderToPlayerPikachu
 	ld a, $5
-	ld [wd49b], a
+	ld [wPikachuEmotionModifier], a
 	ld a, $85
 	ld [wPikachuMood], a
 .notTeachingThunderboltOrThunderToPikachu

--- a/engine/pikachu/pikachu_emotions.asm
+++ b/engine/pikachu/pikachu_emotions.asm
@@ -343,7 +343,7 @@ MapSpecificPikachuExpression:
 	ldpikaemotion a, PikachuEmotion22
 	jr c, .play_emotion
 .notInLavenderTower
-	ld a, [wd49b]
+	ld a, [wPikachuEmotionModifier]
 	and a
 	jr z, .mood_based_emotion
 	dec a

--- a/engine/pokemon/evos_moves.asm
+++ b/engine/pokemon/evos_moves.asm
@@ -373,7 +373,7 @@ LearnMoveFromLevelUp:
 	jr nz, .done
 .foundThunderOrThunderbolt
 	ld a, $5
-	ld [wd49b], a
+	ld [wPikachuEmotionModifier], a
 	ld a, $85
 	ld [wPikachuMood], a
 .done

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -2083,7 +2083,7 @@ wPrinterSettings:: db
 wUnknownSerialFlag_d499:: db
 wPrinterConnectionOpen:: db
 wPrinterOpcode:: db
-wd49b:: db
+wPikachuEmotionModifier:: db
 
 	ds 19
 


### PR DESCRIPTION
This variable serves as an override for Pikachu's emotion following specific events like refusing a Thunder Stone. It is automatically cleared when its mood normalizes.